### PR TITLE
the flattenRef function is merging in any element which matches the n…

### DIFF
--- a/xmltree/xmltree.go
+++ b/xmltree/xmltree.go
@@ -49,6 +49,10 @@ type Element struct {
 	Content []byte
 	// Sub-elements contained within this element.
 	Children []Element
+
+  //the element's depth within the schema
+  //elements with a depth of 0 are immediate children of the XSD's root element (and the children of those elements are 1 etc...)
+  Depth int
 }
 
 // Attr gets the value of the first attribute whose name matches the
@@ -262,7 +266,7 @@ walk:
 	for scanner.scan() {
 		switch tok := scanner.tok.(type) {
 		case xml.StartElement:
-			child := Element{StartElement: tok.Copy(), Scope: el.Scope}
+		  child := Element{StartElement: tok.Copy(), Scope: el.Scope, Depth: depth}
 			if err := child.parse(scanner, data, depth+1); err != nil {
 				return err
 			}

--- a/xsd/index.go
+++ b/xsd/index.go
@@ -8,6 +8,7 @@ import (
 
 type elementKey struct {
 	Name, Type xml.Name
+	Depth int
 }
 
 type schemaIndex struct {
@@ -17,15 +18,15 @@ type schemaIndex struct {
 	idByName map[elementKey]int
 }
 
-func (idx *schemaIndex) ByName(name, typ xml.Name) (*xmltree.Element, bool) {
-	if id, ok := idx.idByName[elementKey{name, typ}]; ok {
+func (idx *schemaIndex) ByName(name xml.Name, typ xml.Name, depth int) (*xmltree.Element, bool) {
+	if id, ok := idx.idByName[elementKey{name, typ, depth}]; ok {
 		return idx.eltByID[id], true
 	}
 	return nil, false
 }
 
-func (idx *schemaIndex) ElementID(name, typ xml.Name) (int, bool) {
-	id, ok := idx.idByName[elementKey{name, typ}]
+func (idx *schemaIndex) ElementID(name xml.Name, typ xml.Name, depth int) (int, bool) {
+	id, ok := idx.idByName[elementKey{name, typ, depth}]
 	return id, ok
 }
 
@@ -40,7 +41,7 @@ func indexSchema(schema []*xmltree.Element) *schemaIndex {
 			index.eltByID = append(index.eltByID, el)
 			if name := el.Attr("", "name"); name != "" {
 				xmlname := el.ResolveDefault(name, tns)
-				index.idByName[elementKey{xmlname, el.Name}] = id
+				index.idByName[elementKey{xmlname, el.Name,  el.Depth}] = id
 			}
 		}
 	}

--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -338,7 +338,8 @@ func flattenRef(schema []*xmltree.Element) error {
 			continue
 		}
 		name := el.Resolve(el.Attr("", "ref"))
-		if dep, ok := index.ElementID(name, el.Name); !ok {
+    //refs should always refer to global elements (so only get elements with depth 0)
+		if dep, ok := index.ElementID(name, el.Name, 0); !ok {
 			return fmt.Errorf("could not find ref %s in %s",
 				el.Attr("", "ref"), el)
 		} else {
@@ -351,7 +352,8 @@ func flattenRef(schema []*xmltree.Element) error {
 			return
 		}
 		ref := el.Resolve(el.Attr("", "ref"))
-		real, ok := index.ByName(ref, el.Name)
+    //refs should always refer to global elements (so only get elements with depth 0)
+		real, ok := index.ByName(ref, el.Name, 0)
 		if !ok {
 			panic("bug building dep tree; missing " + el.Attr("", "ref"))
 		}


### PR DESCRIPTION
…ame and type being referenced, even if that element is not positioned globally within the XSD. This means a clash in names between a global and local element can cause a referencing element to incorrectly have the non global element merged in, rather than the gobal element being referenced.